### PR TITLE
Rudamentary, but still slow, human detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ sample_img/*.jpg
 !sample_img/sample_*.jpg
 sample_img/out/*
 sample_vid
+imgs/*.jpg
+imgs/out/*
 
 # Annotated test results
 results/

--- a/find_humans.py
+++ b/find_humans.py
@@ -1,0 +1,38 @@
+from darkflow.net.build import TFNet
+import cv2
+import glob
+import time
+
+if __name__ == '__main__':
+    options = {"model": "cfg/yolo.cfg", "load": "bin/yolo.weights", "threshold": 0.1}
+
+    tfnet = TFNet(options)
+
+    filenames = [img for img in glob.glob("./imgs/*.jpg")]
+    images = [cv2.imread(img) for img in filenames]
+
+
+    print('Filtering the persons . . . ')
+    start_time = time.time()
+    for i in range(len(images)):
+        results = tfnet.return_predict(images[i])  # results is in JSON format
+        # filtered_results = []
+        filtered_results = [item for item in results if
+                            (item['label'] == 'person' and
+                            item['confidence'] >= 0.2)]
+
+        for item_found in filtered_results:
+            cv2.rectangle(images[i], (item_found['topleft']['x'], item_found['topleft']['y']),
+                          (item_found['bottomright']['x'], item_found['bottomright']['y']),
+                          (0,255,0), 4)
+    elapsed_time = time.time() - start_time
+    print(f'Finished in {elapsed_time}s')
+
+    # Now, filtered_results only contains entries for items labelled "person"
+    # for person in filtered_results:
+    print('Writing images to /imgs/out/ . . . ')
+    start_time = time.time()
+    for i in range(len(images)):
+        cv2.imwrite(f"./imgs/out/image_out_{i}.jpg", images[i])
+    elapsed_time = time.time() - start_time
+    print(f'Finished in {elapsed_time}s')

--- a/find_humans.py
+++ b/find_humans.py
@@ -4,7 +4,7 @@ import glob
 import time
 
 if __name__ == '__main__':
-    options = {"model": "cfg/yolo.cfg", "load": "bin/yolo.weights", "threshold": 0.1}
+    options = {"model": "cfg/yolo.cfg", "load": "bin/yolo.weights", "threshold": 0.25, "gpu": 1.0}
 
     tfnet = TFNet(options)
 
@@ -12,19 +12,20 @@ if __name__ == '__main__':
     images = [cv2.imread(img) for img in filenames]
 
 
+
     print('Filtering the persons . . . ')
     start_time = time.time()
+
     for i in range(len(images)):
         results = tfnet.return_predict(images[i])  # results is in JSON format
-        # filtered_results = []
-        filtered_results = [item for item in results if
-                            (item['label'] == 'person' and
-                            item['confidence'] >= 0.2)]
+
+        filtered_results = [item for item in results if (item['label'] == 'person')]
 
         for item_found in filtered_results:
             cv2.rectangle(images[i], (item_found['topleft']['x'], item_found['topleft']['y']),
                           (item_found['bottomright']['x'], item_found['bottomright']['y']),
                           (0,255,0), 4)
+
     elapsed_time = time.time() - start_time
     print(f'Finished in {elapsed_time}s')
 


### PR DESCRIPTION
Added find_humans.py which uses darkflow to open images in a folder, detect all objects inside, filter out those with person labels, draws rectangles around each person, and writes that to an output image. However, this is a very slow detection, with the slowest part being the detection of all the other objects. The overall process takes ~15 seconds for a sample of 5 images. I attempted to alter the config files so that the neural net only looked for humans, but I didn't get that working. I will keep trying to optimize this detection, but at least it something that works! I will continue to commit to this branch and update this pull-request as I attempt to get some part of it working.